### PR TITLE
feat: add Slide, add classes prop to LinearProgress

### DIFF
--- a/src/MaterialUI.re
+++ b/src/MaterialUI.re
@@ -1313,11 +1313,23 @@ module Select = {
 
 module Slide = {
   [@bs.module "material-ui/transitions/Slide"] external slide : ReasonReact.reactClass = "default";
+  module Direction = {
+    type t =
+      | Up
+      | Down
+      | Left
+      | Right;
+    let to_string =
+      fun
+      | Up => "up"
+      | Down => "down"
+      | Left => "left"
+      | Right => "right";
+  };
   let make =
       (
         ~in_: option(bool)=?,
-        /* TODO: Input Props: direction should be a closed variant */
-        ~direction: option(string)=?,
+        ~direction_: option(Direction.t)=?,
         ~timeout: option({. "enter": float, "exit": float})=?,
         children
       ) =>
@@ -1325,7 +1337,11 @@ module Slide = {
       ~reactClass=slide,
       ~props=
         Js.Nullable.(
-          {"in": unwrap_bool(in_), "direction": from_opt(direction), "timeout": from_opt(timeout)}
+          {
+            "in": unwrap_bool(in_),
+            "direction": from_opt(option_map(Direction.to_string, direction_)),
+            "timeout": from_opt(timeout)
+          }
         ),
       children
     );

--- a/src/MaterialUI.re
+++ b/src/MaterialUI.re
@@ -1311,6 +1311,26 @@ module Select = {
     );
 };
 
+module Slide = {
+  [@bs.module "material-ui/transitions/Slide"] external slide : ReasonReact.reactClass = "default";
+  let make =
+      (
+        ~in_: option(bool)=?,
+        /* TODO: Input Props: direction should be a closed variant */
+        ~direction: option(string)=?,
+        ~timeout: option({. "enter": float, "exit": float})=?,
+        children
+      ) =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass=slide,
+      ~props=
+        Js.Nullable.(
+          {"in": unwrap_bool(in_), "direction": from_opt(direction), "timeout": from_opt(timeout)}
+        ),
+      children
+    );
+};
+
 module TableBody = {
   [@bs.module "material-ui/Table"] external toolbar : ReasonReact.reactClass = "TableBody";
   let make =

--- a/src/MaterialUI.re
+++ b/src/MaterialUI.re
@@ -952,6 +952,7 @@ module LinearProgress = {
   let make =
       (
         ~style: option(ReactDOMRe.style)=?,
+        ~classes: option(Js.t({..}))=?,
         ~className: option(string)=?,
         ~color: option(string)=?,
         ~value: option(int)=?,
@@ -964,6 +965,7 @@ module LinearProgress = {
       ~props=
         Js.Nullable.(
           {
+            "classes": from_opt(classes),
             "style": from_opt(style),
             "mode": from_opt(mode),
             "color": from_opt(color),


### PR DESCRIPTION
- Adds the [`Slide`](https://material-ui-next.com/api/slide/) component, but does not include the props that the underlying `Transition` would use.
- Adds the `classes` prop to the existing `LinearProgress` component.